### PR TITLE
Don't send Connection: keep-alive header to HTTP/2 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Fine! The `Stream` object is entirely convenience. It runs no background routine
 You betcha.
 
 ## Create my own clients
-Clients have to be created off an `http.ResponseWriter` that supports the `http.Flusher` and `http.CloseNotifier` interfaces.
+Clients have to be created off an `http.ResponseWriter` that supports the `http.Flusher` and `http.CloseNotifier` interfaces. When creating a client, callers can optionally also pass the original `http.Request` being served, which helps determine which headers are appropriate to send in response.
 
 `NewClient` _does_ kick off a background routine to handle sending events, so constructing an object literal will not work. This is done because it's assumed you will likely be calling `NewClient` on an http handler routine, and will likely not be doing any interesting work on that routine.
 
 ```go
 func ServeHTTP(w http.ResponseWriter, r *http.Request) {
-  client := eventsource.NewClient(w)
+  client := eventsource.NewClient(w, r)
   if client == nil {
     http.Error(...)
     return

--- a/stream.go
+++ b/stream.go
@@ -161,7 +161,7 @@ func (s *Stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// create the client
-	c := NewClient(w)
+	c := NewClient(w, r)
 	if c == nil {
 		http.Error(w, "EventStream not supported for this connection", http.StatusInternalServerError)
 		return
@@ -188,7 +188,7 @@ func (s *Stream) TopicHandler(topics []string) http.HandlerFunc {
 		}
 
 		// create the client
-		c := NewClient(w)
+		c := NewClient(w, r)
 		if c == nil {
 			http.Error(w, "EventStream not supported for this connection", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
When creating Client instances directly in response to HTTP/2 requests, the `NewClient()` function incorrectly sends the `Connection: keep-alive` header, which is treated as an error by some clients. This pull request changes the `NewClient()` function to additionally take an `http.Request` parameter, whose `ProtoMajor` is checked to determine if sending a `Connection` header is appropriate.

---

As an example, consider the following Client-creating example:

```go
func HandleSSEClient(w http.ResponseWriter, req *http.Request) {
	client := eventsource.NewClient(w)
	go func() {
		for {
			time.Sleep(time.Second)
			client.Send(eventsource.DataEvent("tick"))
		}
	}()
	client.Wait()
}

func main() {
	http.ListenAndServeTLS(":40443", "cert", "key", http.HandlerFunc(HandleSSEClient))
}
```

On macOS 10.13.6, making an HTTP/2 request to this server with `curl` fails:

```
[tim@tevanian ~]$ curl --version
curl 7.54.0 (x86_64-apple-darwin17.0) libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz HTTP2 UnixSockets HTTPS-proxy
[tim@tevanian ~]$ curl -k -v -H "Accept: text/event-source" https://localhost:40443/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 40443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: <self-signed; redacted>
*  start date: Jul 20 02:30:00 2018 GMT
*  expire date: Jul 20 02:30:00 2019 GMT
*  issuer: <self-signed; redacted>
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fad49005800)
> GET / HTTP/2
> Host: localhost:40443
> User-Agent: curl/7.54.0
> Accept: text/event-source
>
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
* http2 error: Invalid HTTP header field was received: frame type: 1, stream: 1, name: [connection], value: [keep-alive]
* HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
* Closing connection 0
* TLSv1.2 (OUT), TLS alert, Client hello (1):
curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
```

After this change, the connection succeeds and begins receiving `tick` events.

---

This change does alter the contract of the `NewRequest()` method; existing code would have to be updated to pass `nil` to preserve old behavior, or pass in a request to benefit from the new behavior. Given the ease of the change, I didn't add another method name for the request-accepting variant, but could do so if asked. (Adding semantic versioning branches or gopkg.in support could also help mitigate this problem, if done before this request is merged.)