### PR TITLE
Stacey/Refactor Broadcast to return successful client count and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ stream.ClientConnectHook(func(r *http.Requset, c *eventsource.Client){
 
 The callback will be on the same goroutine as the incoming web request that created it, but the Client is live and functioning so it'll start receiving broadcasts and publications immediately before your callback has returned.
 
+## Client Send Errors
+If you want to know about errors that occurring when the `Stream` tries to `Send` to individual clients (which will generally be disconnects), use the `Stream.Errors` to create a channel that will deliver them as they happen. The error stream is buffered, but if errors are created faster than they are produced, overflow to the buffer is silently discarded.
+
 ## Graceful shutdown
 The stream's `Shutdown` command will unsubscribe and disconnect all connected clients. However the `Stream` itself is not running any background routines, and may continue to register new clients if it's still registered as an http handler.
 

--- a/stream.go
+++ b/stream.go
@@ -153,6 +153,9 @@ func (s *Stream) Shutdown() {
 // CloseTopic removes all client associations with this topic, but does not
 // terminate them or remove
 func (s *Stream) CloseTopic(topic string) {
+	s.listLock.Lock()
+	defer s.listLock.Unlock()
+
 	for _, topics := range s.clients {
 		topics[topic] = false
 	}


### PR DESCRIPTION
Proposed changes:

- `Stream.Broadcast` to return successful count of clients and errors (from `Client.Send()`)
- `Stream.CloseTopic` to remove the topic from all client topic lists. 